### PR TITLE
Adding option collection_method_map.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 -----------------------------------------------------
 
+0.07  2017-02-15
+  - Renamed method_map to element_method_map and added a similar mapping
+    option to collections (collection_method_map).
+
 0.06  2017-02-14
   - HTTP method map for elements.
 

--- a/lib/Mojolicious/Plugin/Restify.pm
+++ b/lib/Mojolicious/Plugin/Restify.pm
@@ -11,13 +11,13 @@ sub register {
   $conf //= {};
 
   # default HTTP method to instance method mappings for collections
-  $conf->{collection_method_map} = {
+  $conf->{collection_method_map} //= {
     get  => 'list',
     post => 'create',
   };
 
   # default HTTP method to instance method mappings for resource elements
-  $conf->{element_method_map} = {
+  $conf->{element_method_map} //= {
     delete => 'delete',
     get    => 'read',
     patch  => 'patch',


### PR DESCRIPTION
@toratora requested mapping http methods to collections. As I'd recently
mapped http methods to elements, it made sense to add this feature but
rename `method_map` to be more specific -  `collection_method_map` and
`element_method_map` respectively.

Fixes #11 