### PR TITLE
Change regex to be greedier when matching controller.

### DIFF
--- a/lib/Mojolicious/Plugin/Restify.pm
+++ b/lib/Mojolicious/Plugin/Restify.pm
@@ -153,7 +153,7 @@ sub register {
     'restify.current_id' => sub {
       my $c    = shift;
       my $name = $c->stash->{controller};
-      $name =~ s,^.*?\-,,;
+      $name =~ s,^.*\-,,;
       return $c->match->stack->[-1]->{"${name}_id"} // '';
     }
   );


### PR DESCRIPTION
The current_id helper would not work properly if controllers are more than two levels deep. The regex matches only up to the first hyphen.