### PR TITLE
Added support to call alternative methods inside collections

### DIFF
--- a/lib/Mojolicious/Plugin/Restify.pm
+++ b/lib/Mojolicious/Plugin/Restify.pm
@@ -101,6 +101,12 @@ sub register {
           ->name("$options->{route_name}_$method");
       }
 
+      # allow call to alternative methods inside collections
+      # $path/foo calls method foo inside controller
+      $collection->get("list/:action/*opt")->to(action => 'list',
+         opt => undef)->name("$options->{route_name}_actionopt" )
+         if ($options->{allows_optional_action});
+
       return $options->{element}
         ? $collection->element($options->{route_path}, $options)
         : $collection;
@@ -558,6 +564,7 @@ L<Mojolicious::Plugin::Restify> implements the following route shortcuts.
   $r->collection('accounts', placeholder           => '*');
   $r->collection('accounts', prefix                => 'v1');
   $r->collection('accounts', resource_lookup       => '0');
+  $r->collection('accounts', allows_optional_action=> '0');
 
 A L<Mojolicious route shortcut|Mojolicious::Routes/shortcuts> which helps
 create the most common REST L<routes|Mojolicious::Routes::Route> for a
@@ -715,6 +722,13 @@ I<action>.
 
 Enables or disables adding a C<resource_lookup> I<action> to the I<element> of
 the I<collection>.
+
+=item allows_optional_action
+
+  $r->collection('accounts', allows_optional_action => 1)
+
+If set, allow call to alternative methods inside collections so, as an example,
+accounts/foo/bar/1 calls method foo inside controller with bar=1
 
 =back
 

--- a/lib/Mojolicious/Plugin/Restify.pm
+++ b/lib/Mojolicious/Plugin/Restify.pm
@@ -93,7 +93,6 @@ sub register {
       # generate "/$path" collection route
       my $controller
         = $options->{controller} ? "$options->{controller}-$path" : $path;
-
       my $collection = $r->any("/$options->{route_path}")->to("$controller#");
 
       # Map HTTP methods to instance methods/mojo actions
@@ -133,9 +132,8 @@ sub register {
       my $requires_method = $r->can('over') ? 'over' : 'requires';
 
       # generate "/$path/:id" element route with specific placeholder
-      my $element = $r->route("/$options->{placeholder}${path}_id")
-      #my $element = $r->route("/$options->{placeholder}id")
-        ->over($options->{over} => "${path}_id")->name($options->{route_name} . '_id');
+      my $element = $r->any("/$options->{placeholder}${path}_id")
+        ->$requires_method($options->{over} => "${path}_id")->name($options->{route_name} . '_id');
 
       # Generate remaining CRUD routes for "/$path/:id", optionally creating a
       # resource_lookup method for the resource $element.
@@ -149,12 +147,10 @@ sub register {
         ->name("$options->{route_name}_resource_lookup")
         : $element;
 
-
       # Map HTTP methods to instance methods/mojo actions
       while (my ($http_method, $method) = each %{$options->{element_method_map}}) {
-        $under->$http_method->to(app => $options->{real_controller},
-            action => "$method")
-          ->name("$options->{route_name}_$method");
+        $under->$http_method->to("#$method")
+            ->name("$options->{route_name}_$method");
       }
 
       return $element;

--- a/lib/Mojolicious/Plugin/Restify.pm
+++ b/lib/Mojolicious/Plugin/Restify.pm
@@ -103,13 +103,7 @@ sub register {
       }
       # allow call to alternative methods inside collections
       # $path/foo calls method foo inside controller
-      $collection->get("list/:action/*opt")->to(action => 'list',
-         opt => undef)->name("$options->{route_name}_actionopt" )
-         if ($options->{allows_optional_action});
-
-      # allow call to alternative methods inside collections
-      # $path/foo calls method foo inside controller
-      $collection->get("list/:action/*opt")->to(action => 'list',
+      $collection->get("list/:query/*opt")->to(action => 'list',
          opt => undef)->name("$options->{route_name}_actionopt" )
          if ($options->{allows_optional_action});
 

--- a/lib/Mojolicious/Plugin/Restify.pm
+++ b/lib/Mojolicious/Plugin/Restify.pm
@@ -170,7 +170,7 @@ sub register {
   $app->helper(
     'restify.current_id' => sub {
       my $c    = shift;
-      my $name = $c->stash->{app};
+      my $name = $c->stash->{app} || $c->stash->{controller};
       $name =~ s,^.*\-,,;
       $name = (split(/::/, $name))[-1];
       return $c->match->stack->[-1]->{"${name}_id"} // '';
@@ -735,20 +735,6 @@ I<action>.
 
 Enables or disables adding a C<resource_lookup> I<action> to the I<element> of
 the I<collection>.
-
-=item abs_controller
-
-  $r->collection('accounts', abs_controller => 1);
-
-If unset controller name is joined with app namespace. If set to 1 the
-controller name is related only to local paths
-
-=item ns
-
-  $r->collection('accounts', abs_controller => 1, ns => 'anotherNS');
-
-If C<abs_controller> is set, you can set an alternative namespace using
-using this parameter.
 
 =item allows_optional_action
 

--- a/t/allows_optional_action.t
+++ b/t/allows_optional_action.t
@@ -1,0 +1,80 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Test::Mojo;
+
+my $t = Test::Mojo->new('Test::Mojolicious::Plugin::Restify::AllowsOptionalAction');
+
+# call alternative methods
+$t->get_ok("/rest/test/list/baz")->status_is(200)->json_is('/a' => 1);
+# with parameters
+$t->get_ok("/rest/test/list/bac/2")->status_is(200)->json_is('/a' => 2);
+
+done_testing();
+
+package Test::Mojolicious::Plugin::Restify::AllowsOptionalAction;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+    my $self = shift;
+    $self->secrets(["sssshhhhhh!"]);
+
+    # Load the plugin
+    $self->plugin('Mojolicious::Plugin::Restify');
+
+    my $r = $self->routes;
+
+    my $rest = $r->under('/rest')->to(namespace => 'rest', cb => sub {1});
+    $self->restify->routes($rest, ['test'], {allows_optional_action => 1});
+}
+
+1;
+
+package My::Mojo::App::Base;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub catchall {
+  my ($self, $msg) = @_;
+  my $id = $self->stash($self->name . '_id') // '';
+  $self->render(text => "$msg,$id");
+}
+
+sub resource_lookup {1}
+sub create          { shift->catchall('create') }
+sub delete          { shift->catchall('delete') }
+sub list            {
+    my $c = shift;
+    my $query =  $c->stash('query');
+    return $c->$query if ($query);
+    $c->catchall('list')
+}
+sub read            { shift->catchall('read') }
+sub update          { shift->catchall('update') }
+
+sub name {
+  my $self = shift;
+  my $name = $self->stash->{controller};
+  $name =~ s,^.*\-,,;
+  return $name;
+}
+
+sub render_json {
+	my $c		= shift;
+	my $json	= shift;
+	my $status	= shift || 200;
+	$c->render(json => $json, status => $status)
+}
+
+1;
+
+package rest::Test;
+use Mojo::Base 'My::Mojo::App::Base';
+
+sub baz {
+    shift->render_json({a => 1});
+}
+
+sub bac {
+    my $c = shift;
+    $c->render_json({a => $c->stash('opt')});
+}


### PR DESCRIPTION
accounts/list/alt_method/optional/parameters calls list() with stash('query')==alt_method and stash('opt')==optional/parameters so, inside sub list() it's possibile to redirect this request to alternative methods,